### PR TITLE
more fixes

### DIFF
--- a/src/SkewLinearAlgebra.jl
+++ b/src/SkewLinearAlgebra.jl
@@ -141,7 +141,6 @@ Base.real(A::SkewHermitian{<:Real}) = A
 Base.real(A::SkewHermitian) = SkewHermitian(real(A.data))
 Base.imag(A::SkewHermitian) = SkewHermitian(imag(A.data))
 
-Base.copy(A::SkewHermitian) = SkewHermitian(copy(A))
 Base.conj(A::SkewHermitian) = SkewHermitian(conj(A.data))
 Base.conj!(A::SkewHermitian) = SkewHermitian(conj!(A.data))
 LA.tr(A::SkewHermitian{<:Real}) = zero(eltype(A))

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -17,6 +17,11 @@ end
     return complex.(0, vals)
 end
 
+LA.eigvals(A::SkewHermitian, irange::UnitRange) =
+    LA.eigvals!(copyeigtype(A), irange)
+LA.eigvals(A::SkewHermitian, vl::Real,vh::Real) =
+    LA.eigvals!(copyeigtype(A), vl,vh)
+
 # no need to define LA.eigen(...) since the generic methods should work
 
 @views function skeweigvals!(S::SkewHermitian)
@@ -180,7 +185,7 @@ end
 
 """
     SkewEigen
-Type returned by eigen(A::SkewHermitian). It contains the eigenvalues and the eigenvectors. 
+Type returned by eigen(A::SkewHermitian). It contains the eigenvalues and the eigenvectors.
 The eigenvectors are separated between real and imaginary part.
 """
 struct SkewEigen{val<:AbstractVector,Qr<:AbstractMatrix,Qim<:AbstractMatrix}
@@ -195,8 +200,9 @@ Base.size(F::SkewEigen) = size(F.values)
 
 LA.eigen!(A::SkewHermitian) = skeweigen!(A)
 
-LA.eigen(A::SkewHermitian) =
-    LA.eigen!(copyto!(similar(A, LA.eigtype(eltype(A))), A))
+copyeigtype(A) = copyto!(similar(A, LA.eigtype(eltype(A))), A)
+
+LA.eigen(A::SkewHermitian) = LA.eigen!(copyeigtype(A))
 
 @views function LA.svdvals!(A::SkewHermitian)
     n=size(A,1)
@@ -226,4 +232,4 @@ end
     return LA.SVD(U,vals,adjoint(V))
 end
 
-LA.svd(A::SkewHermitian) = svd!(copy(A))
+LA.svd(A::SkewHermitian) = svd!(copyeigtype(A))

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -30,7 +30,7 @@ function skewexp!(A::SkewHermitian)
 end
 
 function Base.exp(A::SkewHermitian)
-    return skewexp!(copy(A))
+    return skewexp!(copyeigtype(A))
 end
 
 function skewcis!(A::SkewHermitian)
@@ -91,9 +91,9 @@ end
     Q1 .-= temp2
     return Q1
 end
-Base.cis(A::SkewHermitian) = skewcis!(copy(A))
-Base.cos(A::SkewHermitian) = skewcos!(copy(A))
-Base.sin(A::SkewHermitian) = skewsin!(copy(A))
+Base.cis(A::SkewHermitian) = skewcis!(copyeigtype(A))
+Base.cos(A::SkewHermitian) = skewcos!(copyeigtype(A))
+Base.sin(A::SkewHermitian) = skewsin!(copyeigtype(A))
 
 function Base.tan(A::SkewHermitian)
     E=cis(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,25 @@ using Test
 
 Random.seed!(314159) # use same pseudorandom stream for every test
 
+@testset "README.md" begin # test from the README examples
+    A = [0 2 -7 4; -2 0 -8 3; 7 8 0 1;-4 -3 -1 0]
+    @test SLA.isskewhermitian(A)
+    A = SLA.SkewHermitian(A)
+    @test tr(A) == 0
+    @test det(A) ≈ 81
+    @test SLA.isskewhermitian(inv(A))
+    @test inv(A) ≈ [0 1 -3 -8; -1 0 4 7; 3 -4 0 2; 8 -7 -2 0]/9
+    @test A \ [1,2,3,4] ≈ [-13,13,1,-4]/3
+    v = [8.306623862918073, 8.53382018538718, -1.083472677771923]
+    @test hessenberg(A).H ≈ Tridiagonal(v,[0,0,0,0.],-v)
+    iλ₁,iλ₂ = 11.93445871397423, 0.7541188264752862
+    @test eigvals(A) ≈ [iλ₁,iλ₂,-iλ₂,-iλ₁]*im
+    @test SLA.getQ(hessenberg(A)) ≈ [1.0 0.0 0.0 0.0; 0.0 -0.2407717061715382 -0.9592700375676934 -0.14774972261267352; 0.0 0.8427009716003843 -0.2821382463434394 0.4585336219014009; 0.0 -0.48154341234307674 -0.014106912317171805 0.8763086996337883]
+    @test eigvals(A, 0,15) ≈ [iλ₁,iλ₂]*im
+    @test eigvals(A, 1:3) ≈ [iλ₁,iλ₂,-iλ₂]*im
+    @test svdvals(A) ≈ [iλ₁,iλ₁,iλ₂,iλ₂]
+end
+
 @testset "SkewLinearAlgebra.jl" begin
     for n in [2,20,153,200]
         A=SLA.skewhermitian(randn(n,n))


### PR DESCRIPTION
More fixes:

* added back missing methods for `eigvals(A, range)` (since the LinearAlgebra ones only handle Symmetric/Hermitian)
* remove duplicate `copy` method
* add tests based on the `README.md` examples, and fixed some of the example output
* various editing of the README (note that github markdown does not accept arbitrary latex, and only recently got support for latex equations)