### PR TITLE
remove duplicate set_nb definition

### DIFF
--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -305,16 +305,6 @@ end
     end)
     return
 end
-function set_nb(n::Integer)
-    if n<=12
-        return max(n-4,1)
-    elseif n<=100
-        return 10
-    else
-        return 60
-    end
-    return 1
-end
 
 @views function csktrd!(S::SkewHermitian{<:Real})
     n = size(S.data,1)


### PR DESCRIPTION
This function was (identically) defined twice, causing a warning during precompilation.

(In general you might want to go through the code and delete anything that is no longer needed.)