### PR TITLE
rm duplicate definitions, fix tridiagonal display

### DIFF
--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -77,7 +77,7 @@ SkewHermTridiagonal(S::SkewHermTridiagonal) = S
 
 AbstractMatrix{T}(S::SkewHermTridiagonal) where {T} =
     SkewHermTridiagonal(convert(AbstractVector{T}, S.ev)::AbstractVector{T})
-    
+
 function Base.Matrix{T}(M::SkewHermTridiagonal) where T
     n = size(M, 1)
     Mf = zeros(T, n, n)
@@ -118,9 +118,7 @@ end
 
 Base.transpose(S::SkewHermTridiagonal) = -S
 Base.adjoint(S::SkewHermTridiagonal{<:Real}) = -S
-Base.adjoint(S::SkewHermTridiagonal) = -conj.(S)
-
-Base.copy(S::SkewHermTridiagonal)=SkewHermTridiagonal(copy(S.ev))
+Base.adjoint(S::SkewHermTridiagonal) = .-conj.(S)
 Base.copy(S::LA.Adjoint{<:Any,<:SkewHermTridiagonal}) = SkewHermTridiagonal(map(x -> copy.(adjoint.(x)), (S.parent.ev))...)
 
 isskewhermitian(S::SkewHermTridiagonal) = true
@@ -263,7 +261,7 @@ end
             Qdiag[i+1,j] = trisol.vectors[i+1,j]*c*1im
             c *= (-1)
         end
-        
+
     end
     if n%2==1
         Qdiag[n,:]=trisol.vectors[n,:]*c
@@ -276,8 +274,6 @@ end
 @views function LA.eigen!(A::SkewHermTridiagonal)
      return skewtrieigen!(A)
 end
-
-copyeigtype(A) = copyto!(similar(A, LA.eigtype(eltype(A))), A)
 
 LA.eigen(A::SkewHermTridiagonal) = LA.eigen!(copyeigtype(A))
 
@@ -319,10 +315,15 @@ LA.svd(A::SkewHermTridiagonal) = svd!(copyeigtype(A))
 #det(A::SkewHermTridiagonal; shift::Number=false) = det_usmani(A.ev, A.dv, A.ev, shift)
 #logabsdet(A::SkewHermTridiagonal; shift::Number=false) = logabsdet(ldlt(A; shift=shift))
 
+# show a "⋅" for structural zeros when printing
+function Base.replace_in_print_matrix(A::SkewHermTridiagonal, i::Integer, j::Integer, s::AbstractString)
+    i==j-1||i==j||i==j+1 ? s : Base.replace_with_centered_mark(s)
+end
+
 @inline function Base.getindex(A::SkewHermTridiagonal{T}, i::Integer, j::Integer) where T
     @boundscheck checkbounds(A, i, j)
     if i == j + 1
-        return @inbounds A.ev[j] 
+        return @inbounds A.ev[j]
     elseif i + 1 == j
         return @inbounds -A.ev[i]'
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,7 @@ end
         @test Matrix(HA.H) ≈ Matrix(HB.H)
         @test Matrix(HA.Q) ≈ Matrix(HB.Q)
     end
-    
+
     A=zeros(4,4)
     A[2:4,1]=ones(3)
     A[1,2:4]=-ones(3)
@@ -131,7 +131,7 @@ end
     HA=hessenberg(A)
     HB=hessenberg(B)
     @test Matrix(HA.H)≈Matrix(HB.H)
-    
+
 end
 @testset "eigen.jl" begin
     for n in [2,20,153,200]
@@ -175,7 +175,7 @@ end
 end
 
 
-@testset "tridiag.jl" begin 
+@testset "tridiag.jl" begin
     for n in [2,20,151,200]
         C=SLA.skewhermitian(randn(n,n))
         A=SLA.SkewHermTridiagonal(C)
@@ -209,6 +209,9 @@ end
         @test real(Svd.U*Diagonal(Svd.S)*Svd.Vt) ≈ B
         @test svdvals(A)≈svdvals(B)
 
+        B = SLA.SkewHermTridiagonal([3,4,5])
+        @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
+        @test repr("text/plain", B) == "4×4 SkewHermTridiagonal{Int64, Vector{Int64}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,7 +217,7 @@ end
 
         B = SLA.SkewHermTridiagonal([3,4,5])
         @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
-        @test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{Int64, Vector{Int64}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
+        @test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{$Int, Vector{$Int}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
 
         Ac = SLA.SkewHermTridiagonal(randn(ComplexF64, n))
         for f in (real, imag)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,7 @@ end
 
         B = SLA.SkewHermTridiagonal([3,4,5])
         @test B == [0 -3 0 0; 3 0 -4 0; 0 4 0 -5; 0 0 5 0]
-        @test repr("text/plain", B) == "4×4 SkewHermTridiagonal{Int64, Vector{Int64}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
+        @test repr("text/plain", B) == "4×4 SkewLinearAlgebra.SkewHermTridiagonal{Int64, Vector{Int64}}:\n 0  -3   ⋅   ⋅\n 3   0  -4   ⋅\n ⋅   4   0  -5\n ⋅   ⋅   5   0"
     end
 end
 


### PR DESCRIPTION
Removed a couple of duplicate method definitions that Julia was complaining about.  Also fixed the display to show structural zeros as `.`:
```jl
julia> B = SkewHermTridiagonal([3,4,5])
4×4 SkewHermTridiagonal{Int64, Vector{Int64}}:
 0  -3   ⋅   ⋅
 3   0  -4   ⋅
 ⋅   4   0  -5
 ⋅   ⋅   5   0
```