### PR TITLE
bugfix for imag(::SkewHermTridiagonal)

### DIFF
--- a/src/SkewLinearAlgebra.jl
+++ b/src/SkewLinearAlgebra.jl
@@ -118,11 +118,11 @@ isskewhermitian(a::Number) = a == -a'
 Transforms `A` in-place to its skew-Hermitian part `(A-A')/2`,
 and returns a [`SkewHermitian`](@ref) view.
 """
-function skewhermitian!(A::AbstractMatrix{<:Number})
+function skewhermitian!(A::AbstractMatrix{T}) where {T<:Number}
     LA.require_one_based_indexing(A)
     n = LA.checksquare(A)
     @inbounds for i in 1:n
-        A[i,i] = imag(A[i,i])
+        A[i,i] = T isa Real ? zero(T) : complex(zero(real(T)),imag(A[i,i]))
         for j = 1:i-1
             a = (A[i,j] - A[j,i]')/2
             A[i,j] = a
@@ -138,7 +138,7 @@ Base.transpose(A::SkewHermitian) = SkewHermitian(transpose(A.data))
 Base.adjoint(A::SkewHermitian) = SkewHermitian(A.data')
 Base.real(A::SkewHermitian{<:Real}) = A
 Base.real(A::SkewHermitian) = SkewHermitian(real(A.data))
-Base.imag(A::SkewHermitian) = SkewHermitian(imag(A.data))
+Base.imag(A::SkewHermitian) = LA.Hermitian(imag(A.data))
 
 Base.conj(A::SkewHermitian) = SkewHermitian(conj(A.data))
 Base.conj!(A::SkewHermitian) = SkewHermitian(conj!(A.data))
@@ -233,7 +233,7 @@ LA.kron(A::StridedMatrix,B::SkewHermitian) = kron(A,B.data)
 @views function LA.schur!(A::SkewHermitian)
     F=eigen!(A)
     return Schur(typeof(F.vectors)(Diagonal(F.values)), F.vectors, F.values)
-    
+
 end
 LA.schur(A::SkewHermitian)= LA.schur!(copy(A))
 

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -77,7 +77,7 @@ SkewHermTridiagonal(S::SkewHermTridiagonal) = S
 
 AbstractMatrix{T}(S::SkewHermTridiagonal) where {T} =
     SkewHermTridiagonal(convert(AbstractVector{T}, S.ev)::AbstractVector{T})
-    
+
 function Base.Matrix{T}(M::SkewHermTridiagonal) where T
     n = size(M, 1)
     Mf = zeros(T, n, n)
@@ -112,8 +112,12 @@ Base.copyto!(dest::SkewHermTridiagonal, src::SkewHermTridiagonal) =
     (copyto!(dest.ev, src.ev); dest)
 
 #Elementary operations
-for func in (:conj, :copy, :real, :imag)
+for func in (:conj, :copy, :real)
     @eval Base.$func(M::SkewHermTridiagonal) = SkewHermTridiagonal(($func)(M.ev))
+end
+function Base.imag(M::SkewHermTridiagonal)
+    ev = imag(M.ev)
+    return LA.SymTridiagonal(similar(ev, length(ev)+1) .= 0, ev)
 end
 
 Base.transpose(S::SkewHermTridiagonal) = -S
@@ -263,7 +267,7 @@ end
             Qdiag[i+1,j] = trisol.vectors[i+1,j]*c*1im
             c *= (-1)
         end
-        
+
     end
     if n%2==1
         Qdiag[n,:]=trisol.vectors[n,:]*c
@@ -322,7 +326,7 @@ LA.svd(A::SkewHermTridiagonal) = svd!(copyeigtype(A))
 @inline function Base.getindex(A::SkewHermTridiagonal{T}, i::Integer, j::Integer) where T
     @boundscheck checkbounds(A, i, j)
     if i == j + 1
-        return @inbounds A.ev[j] 
+        return @inbounds A.ev[j]
     elseif i + 1 == j
         return @inbounds -A.ev[i]'
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,11 @@ end
         A = SLA.skewhermitian(randn(n,n))
         F = schur(A)
         @test A.data ≈ F.vectors * F.Schur * F.vectors'
+
+        Ac = SLA.skewhermitian!(randn(ComplexF64, n, n))
+        for f in (real, imag)
+            @test f(Ac) == f(Matrix(Ac))
+        end
     end
 end
 @testset "hessenberg.jl" begin
@@ -209,7 +214,7 @@ end
         @test real(Svd.U*Diagonal(Svd.S)*Svd.Vt) ≈ B
         @test svdvals(A)≈svdvals(B)
 
-        Ac = rand(ComplexF64, n,n)
+        Ac = SLA.SkewHermTridiagonal(randn(ComplexF64, n))
         for f in (real, imag)
             @test f(Ac) == f(Matrix(Ac))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,7 @@ end
         @test Matrix(HA.H) ≈ Matrix(HB.H)
         @test Matrix(HA.Q) ≈ Matrix(HB.Q)
     end
-    
+
     A=zeros(4,4)
     A[2:4,1]=ones(3)
     A[1,2:4]=-ones(3)
@@ -131,7 +131,7 @@ end
     HA=hessenberg(A)
     HB=hessenberg(B)
     @test Matrix(HA.H)≈Matrix(HB.H)
-    
+
 end
 @testset "eigen.jl" begin
     for n in [2,20,153,200]
@@ -175,7 +175,7 @@ end
 end
 
 
-@testset "tridiag.jl" begin 
+@testset "tridiag.jl" begin
     for n in [2,20,151,200]
         C=SLA.skewhermitian(randn(n,n))
         A=SLA.SkewHermTridiagonal(C)
@@ -209,6 +209,10 @@ end
         @test real(Svd.U*Diagonal(Svd.S)*Svd.Vt) ≈ B
         @test svdvals(A)≈svdvals(B)
 
+        Ac = rand(ComplexF64, n,n)
+        for f in (real, imag)
+            @test f(Ac) == f(Matrix(Ac))
+        end
     end
 end
 


### PR DESCRIPTION
The imaginary part of a `SkewHermTridiagonal` is a real `SymTridiagonal` matrix, not a `SkewHermTridiagonal` matrix.

Similar fix for `imag(::SkewHermitian)`, and also fixed the `skewhermitian!` function for complex matrices.